### PR TITLE
Removed OpenAIP navaid layer

### DIFF
--- a/EndOfBody.html
+++ b/EndOfBody.html
@@ -60,15 +60,17 @@ if(VRS && VRS.globalDispatch && VRS.serverConfig) {
           }
         });
 
+// Note: OpenAIP no longer servers navaids
 // Add Open AIP navaids
-   		var openAIPnav = L.tileLayer('https://{s}.api.tiles.openaip.net/api/data/navaids/{z}/{x}/{y}.png?apiKey='+ OPENAIPKEY, {
-            opacity: 0.6,
-			maxZoom: 19,
-			minZoom: 1,
-			id: 'OpenAIPna',
-			transparent: true,
-        });
-   		var tacanVOR = L.layerGroup([openAIPnav, ukNavaidsGeoJSON]);
+//   		var openAIPnav = L.tileLayer('https://{s}.api.tiles.openaip.net/api/data/navaids/{z}/{x}/{y}.png?apiKey='+ OPENAIPKEY, {
+//           opacity: 0.6,
+//			maxZoom: 19,
+//			minZoom: 1,
+//			id: 'OpenAIPna',
+//			transparent: true,
+//        });
+//   		var tacanVOR = L.layerGroup([openAIPnav, ukNavaidsGeoJSON]);
+		var tacanVOR = L.layerGroup([ukNavaidsGeoJSON]);
 
 // Add marker icons
     var civIcon = L.AwesomeMarkers.icon({


### PR DESCRIPTION
OpenAIP no longer serves navaid tiles. Having navaid layer turned on produced errors in devtools.
![image](https://user-images.githubusercontent.com/7931765/236700350-ebda9e30-6d95-4e13-a2e1-dc58918ca636.png)
Querying these URLs produces:
`{"message":"Unknown layer 'navaids'"}`

Thus I've commented out the bit that requested the navaid tile layer. Only the navaid geosjon will be used. In testing, the errors are gone, hooray.